### PR TITLE
cmd.exeのプロセスを起動時に1回のみ生成する機能実装

### DIFF
--- a/ChatData.cpp
+++ b/ChatData.cpp
@@ -1,0 +1,51 @@
+#include "SingleLock.h"
+#include "ChatData.h"
+
+ChatData::ChatData()
+{
+}
+
+ChatData::~ChatData()
+{
+}
+
+ChatData* ChatData::Get()
+{
+	static ChatData chatData;
+	return &chatData;
+}
+
+const std::wstring& ChatData::GetPrompt() const
+{
+	SingleLock sl(&csPrompt_);
+
+	return prompt_;
+}
+
+void ChatData::SetPrompt(const std::wstring& prompt)
+{
+	SingleLock sl(&csPrompt_);
+
+	prompt_ = prompt;
+}
+
+BOOL ChatData::PopFrontOutput(std::wstring* output)
+{
+	SingleLock sl(&csOutputs_);
+
+	if (outputs_.empty()) {
+		output->clear();
+		return FALSE;
+	}
+
+	*output = outputs_.front();
+	outputs_.pop_front();
+	return TRUE;
+}
+
+void ChatData::PushBackOutput(const std::wstring& output)
+{
+	SingleLock sl(&csOutputs_);
+
+	outputs_.push_back(output);
+}

--- a/ChatData.h
+++ b/ChatData.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <list>
+#include <string>
+#include "CriticalSection.h"
+
+class ChatData
+{
+private:
+	ChatData();
+	~ChatData();
+
+public:
+	static ChatData* Get();
+
+	const std::wstring& GetPrompt() const;
+	void SetPrompt(const std::wstring& prompt);
+
+	BOOL PopFrontOutput(std::wstring* output);
+	void PushBackOutput(const std::wstring& output);
+
+private:
+	mutable CriticalSection csPrompt_;
+	std::wstring prompt_;
+
+	mutable CriticalSection csOutputs_;
+	std::list<std::wstring> outputs_;
+};

--- a/CmdProcess.cpp
+++ b/CmdProcess.cpp
@@ -167,7 +167,7 @@ namespace
 		return str;
 	}
 
-	void TrimStringLine(std::wstring* pwstr)
+	void TrimStringLine(std::wstring* pwstr, BOOL commandLineErase)
 	{
 		const size_t last = pwstr->find_last_of(L'\n');
 		if (last != std::wstring::npos) {
@@ -176,7 +176,9 @@ namespace
 
 		const size_t first = pwstr->find_first_of(L'\n');
 		if (first != std::wstring::npos) {
-			pwstr->erase(0, first);
+			if (commandLineErase) {
+				pwstr->erase(0, first);
+			}
 		}
 	}
 
@@ -196,7 +198,8 @@ CmdProcess::CmdProcess() :
 	writePipeStdOut_{ NULL },
 	threadProcess_{ NULL },
 	threadReadStdOut_{ NULL },
-	eventExit_{ NULL }
+	eventExit_{ NULL },
+	commandLineErase_{ FALSE }
 {
 }
 
@@ -344,6 +347,8 @@ BOOL CmdProcess::RunCommand(LPCWSTR lpszCommand)
 		return FALSE;
 	}
 
+	commandLineErase_ = TRUE;
+
 	return TRUE;
 }
 
@@ -425,7 +430,11 @@ void CmdProcess::ReadStdOut()
 					std::string str(buffers.cbegin(), buffers.cend());
 					buffers.clear();
 					std::wstring wstr = ToWString(str);
-					TrimStringLine(&wstr);
+					TrimStringLine(&wstr, commandLineErase_);
+					if (commandLineErase_ == TRUE) {
+						commandLineErase_ = FALSE;
+					}
+
 					ChatData::Get()->PushBackOutput(wstr);
 					PostMessageW(hwnd_, WM_APP, 0, 0);
 				}

--- a/CmdProcess.cpp
+++ b/CmdProcess.cpp
@@ -1,0 +1,232 @@
+#include <windows.h>
+#include <atlbase.h>
+#include <atlhost.h>
+#include <string>
+#include <vector>
+#include <winternl.h>
+#include "CmdProcess.h"
+
+namespace
+{
+	std::wstring ToWString(const std::string& str)
+	{
+		const int size = MultiByteToWideChar(CP_THREAD_ACP, 0, str.c_str(), static_cast<int>(str.length()), NULL, 0);
+
+		std::wstring wstr;
+		if (size > 0)
+		{
+			std::vector<wchar_t> buffers(size, L'\0');
+			MultiByteToWideChar(CP_THREAD_ACP, 0, str.c_str(), static_cast<int>(str.length()), &buffers.front(), size);
+			wstr.assign(buffers.cbegin(), buffers.cend());
+		}
+
+		return wstr;
+	}
+
+	std::string ToString(const std::wstring& wstr)
+	{
+		const int size = WideCharToMultiByte(CP_THREAD_ACP, 0, wstr.c_str(), static_cast<int>(wstr.length()), NULL, 0, NULL, NULL);
+
+		std::string str;
+		if (size > 0)
+		{
+			std::vector<char> buffers(size, '\0');
+			WideCharToMultiByte(CP_THREAD_ACP, 0, wstr.c_str(), static_cast<int>(wstr.length()), &buffers.front(), size, NULL, NULL);
+			str.assign(buffers.cbegin(), buffers.cend());
+		}
+
+		return str;
+	}
+
+	void TrimFirstLastLine(std::wstring* pwstr)
+	{
+		const size_t last = pwstr->find_last_of(L'\n');
+		if (last != std::wstring::npos) {
+			pwstr->erase(last);
+		}
+
+		const size_t first = pwstr->find_first_of(L'\n');
+		if (first != std::wstring::npos) {
+			pwstr->erase(0, first);
+		}
+	}
+}
+
+CmdProcess::CmdProcess() :
+	hProcess_{ NULL },
+	readPipeStdIn_{ NULL },
+	writePipeStdIn_{ NULL },
+	readPipeStdOut_{ NULL },
+	writePipeStdOut_{ NULL }
+{
+}
+
+CmdProcess::~CmdProcess()
+{
+}
+
+CmdProcess* CmdProcess::Get()
+{
+	static CmdProcess singleton;
+	return &singleton;
+}
+
+BOOL CmdProcess::Create()
+{
+	WCHAR szCmdExePath[MAX_PATH] = { 0 };
+	if (GetEnvironmentVariableW(L"ComSpec", szCmdExePath, _countof(szCmdExePath)) == 0)
+	{
+		return FALSE;
+	}
+
+	HANDLE readPipeStdIn = NULL;
+	HANDLE writePipeStdIn = NULL;
+	HANDLE readPipeStdOut = NULL;
+	HANDLE writePipeStdOut = NULL;
+
+	SECURITY_ATTRIBUTES sa = { 0 };
+	sa.nLength = sizeof(sa);
+	sa.bInheritHandle = TRUE;
+
+	if (CreatePipe(&readPipeStdIn, &writePipeStdIn, &sa, 0) == FALSE) {
+		return FALSE;
+	}
+
+	if (CreatePipe(&readPipeStdOut, &writePipeStdOut, &sa, 0) == FALSE) {
+		CloseHandle(readPipeStdIn);
+		CloseHandle(writePipeStdIn);
+		return FALSE;
+	}
+
+	STARTUPINFOW si = { 0 };
+	si.cb = sizeof(si);
+	si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+	si.hStdOutput = writePipeStdOut;
+	si.hStdInput = readPipeStdIn;
+	si.hStdError = writePipeStdOut;
+	si.wShowWindow = SW_HIDE;
+
+	std::wstring commandLine = szCmdExePath;
+
+	std::vector<wchar_t> commandLineBuffer(commandLine.c_str(), commandLine.c_str() + commandLine.length() + 1);
+
+	PROCESS_INFORMATION pi = { 0 };
+	if (CreateProcessW(NULL, &commandLineBuffer.front(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi) == FALSE) {
+		CloseHandle(readPipeStdIn);
+		CloseHandle(writePipeStdIn);
+		CloseHandle(readPipeStdOut);
+		CloseHandle(writePipeStdOut);
+		return FALSE;
+	}
+
+	WaitForSingleObject(pi.hProcess, 1000);
+
+	CloseHandle(pi.hThread);
+
+	hProcess_ = pi.hProcess;
+	readPipeStdIn_ = readPipeStdIn;
+	writePipeStdIn_ = writePipeStdIn;
+	readPipeStdOut_ = readPipeStdOut;
+	writePipeStdOut_ = writePipeStdOut;
+
+	return TRUE;
+}
+
+BOOL CmdProcess::Exit()
+{
+	if (hProcess_)
+	{
+		TerminateProcess(hProcess_, 0);
+		CloseHandle(hProcess_);
+		hProcess_ = NULL;
+	}
+
+	if (readPipeStdIn_) {
+		CloseHandle(readPipeStdIn_);
+		readPipeStdIn_ = NULL;
+	}
+
+	if (writePipeStdIn_) {
+		CloseHandle(writePipeStdIn_);
+		writePipeStdIn_ = NULL;
+	}
+
+	if (readPipeStdOut_) {
+		CloseHandle(readPipeStdOut_);
+		readPipeStdOut_ = NULL;
+	}
+
+	if (writePipeStdOut_) {
+		CloseHandle(writePipeStdOut_);
+		writePipeStdOut_ = NULL;
+	}
+
+	return TRUE;
+}
+
+LPWSTR CmdProcess::RunCommand(LPCWSTR lpszCommand)
+{
+	if (hProcess_ == NULL) {
+		return nullptr;
+	}
+
+	if (readPipeStdIn_ == NULL) {
+		return nullptr;
+	}
+
+	if (writePipeStdIn_ == NULL) {
+		return nullptr;
+	}
+
+	if (readPipeStdOut_ == NULL) {
+		return nullptr;
+	}
+
+	if (writePipeStdOut_ == NULL) {
+		return nullptr;
+	}
+
+	if (!lpszCommand) {
+		return nullptr;
+	}
+
+	WaitForSingleObject(hProcess_, 1000);
+
+	std::wstring command = lpszCommand;
+	command += L"\n";
+
+	std::string writeBuf = ToString(command);
+	if (WriteFile(writePipeStdIn_, &writeBuf.front(), static_cast<DWORD>(writeBuf.length()), NULL, NULL) == FALSE) {
+		return nullptr;
+	}
+
+	LPWSTR lpszReturn = L"";
+
+	CHAR readBuf[1025];
+	std::string str;
+	BOOL end = FALSE;
+	do {
+		WaitForSingleObject(hProcess_, 1000);
+		DWORD totalLen, len;
+		if (PeekNamedPipe(readPipeStdOut_, NULL, 0, NULL, &totalLen, NULL) && totalLen > 0) {
+			if (ReadFile(readPipeStdOut_, readBuf, sizeof(readBuf) - 1, &len, NULL) && len > 0) {
+				readBuf[len] = '\0';
+				str += readBuf;
+			}
+		}
+		else
+		{
+			end = TRUE;
+		}
+	} while (!end);
+	if (str.empty() == false) {
+		std::wstring wstr = ToWString(str);
+		TrimFirstLastLine(&wstr);
+		lpszReturn = static_cast<LPWSTR>(GlobalAlloc(0, (wstr.length() + 1) * sizeof(WCHAR)));
+		if (lpszReturn) {
+			wcsncpy_s(lpszReturn, wstr.length() + 1, wstr.c_str(), wstr.length() + 1);
+		}
+	}
+
+	return lpszReturn;
+}

--- a/CmdProcess.cpp
+++ b/CmdProcess.cpp
@@ -4,10 +4,139 @@
 #include <string>
 #include <vector>
 #include <winternl.h>
+#include "ChatData.h"
 #include "CmdProcess.h"
 
 namespace
 {
+	/******************************************************************************\
+	*       This is a part of the Microsoft Source Code Samples.
+	*       Copyright 1995 - 1997 Microsoft Corporation.
+	*       All rights reserved.
+	*       This source code is only intended as a supplement to
+	*       Microsoft Development Tools and/or WinHelp documentation.
+	*       See these sources for detailed information regarding the
+	*       Microsoft samples programs.
+	\******************************************************************************/
+
+	/*++
+	Copyright (c) 1997  Microsoft Corporation
+	Module Name:
+		pipeex.c
+	Abstract:
+		CreatePipe-like function that lets one or both handles be overlapped
+	Author:
+		Dave Hart  Summer 1997
+	Revision History:
+	--*/
+	BOOL CreatePipeEx(
+		LPHANDLE lpReadPipe,
+		LPHANDLE lpWritePipe,
+		LPSECURITY_ATTRIBUTES lpPipeAttributes,
+		DWORD nSize,
+		DWORD dwReadMode,
+		DWORD dwWriteMode
+	)
+		/*++
+		Routine Description:
+			The CreatePipeEx API is used to create an anonymous pipe I/O device.
+			Unlike CreatePipe FILE_FLAG_OVERLAPPED may be specified for one or
+			both handles.
+			Two handles to the device are created.  One handle is opened for
+			reading and the other is opened for writing.  These handles may be
+			used in subsequent calls to ReadFile and WriteFile to transmit data
+			through the pipe.
+		Arguments:
+			lpReadPipe - Returns a handle to the read side of the pipe.  Data
+				may be read from the pipe by specifying this handle value in a
+				subsequent call to ReadFile.
+			lpWritePipe - Returns a handle to the write side of the pipe.  Data
+				may be written to the pipe by specifying this handle value in a
+				subsequent call to WriteFile.
+			lpPipeAttributes - An optional parameter that may be used to specify
+				the attributes of the new pipe.  If the parameter is not
+				specified, then the pipe is created without a security
+				descriptor, and the resulting handles are not inherited on
+				process creation.  Otherwise, the optional security attributes
+				are used on the pipe, and the inherit handles flag effects both
+				pipe handles.
+			nSize - Supplies the requested buffer size for the pipe.  This is
+				only a suggestion and is used by the operating system to
+				calculate an appropriate buffering mechanism.  A value of zero
+				indicates that the system is to choose the default buffering
+				scheme.
+		Return Value:
+			TRUE - The operation was successful.
+			FALSE/NULL - The operation failed. Extended error status is available
+				using GetLastError.
+		--*/
+	{
+		static volatile LONG pipeSerialNumber = 0L;
+
+		WCHAR PipeNameBuffer[MAX_PATH];
+
+		//
+		// Only one valid OpenMode flag - FILE_FLAG_OVERLAPPED
+		//
+
+		//if ((dwReadMode | dwWriteMode) & (~FILE_FLAG_OVERLAPPED)) {
+		//	SetLastError(ERROR_INVALID_PARAMETER);
+		//	return FALSE;
+		//}
+
+		//
+		//  Set the default timeout to 120 seconds
+		//
+
+		if (nSize == 0) {
+			nSize = 4096;
+		}
+
+		swprintf_s(
+			PipeNameBuffer,
+			L"\\\\.\\Pipe\\RemoteExeAnon.%08x.%08x",
+			GetCurrentProcessId(),
+			InterlockedIncrement(&pipeSerialNumber)
+		);
+
+		HANDLE ReadPipeHandle = CreateNamedPipeW(
+			PipeNameBuffer,
+			PIPE_ACCESS_INBOUND | dwReadMode,
+			PIPE_TYPE_BYTE | PIPE_WAIT,
+			1,             // Number of pipes
+			nSize,         // Out buffer size
+			nSize,         // In buffer size
+			120 * 1000,    // Timeout in ms
+			lpPipeAttributes
+		);
+
+		if (INVALID_HANDLE_VALUE == ReadPipeHandle) {
+			return FALSE;
+		}
+
+		HANDLE WritePipeHandle = CreateFileW(
+			PipeNameBuffer,
+			GENERIC_WRITE,
+			0,                         // No sharing
+			lpPipeAttributes,
+			OPEN_EXISTING,
+			FILE_ATTRIBUTE_NORMAL | dwWriteMode,
+			NULL                       // Template file
+		);
+
+		if (INVALID_HANDLE_VALUE == WritePipeHandle) {
+			const DWORD dwError = GetLastError();
+			CloseHandle(ReadPipeHandle);
+			SetLastError(dwError);
+			return FALSE;
+		}
+
+		*lpReadPipe = ReadPipeHandle;
+		*lpWritePipe = WritePipeHandle;
+
+		return TRUE;
+	}
+
 	std::wstring ToWString(const std::string& str)
 	{
 		const int size = MultiByteToWideChar(CP_THREAD_ACP, 0, str.c_str(), static_cast<int>(str.length()), NULL, 0);
@@ -56,13 +185,6 @@ namespace
 		return reinterpret_cast<HANDLE>(_beginthreadex(nullptr, 0, startAddress, argList, 0, nullptr));
 	}
 
-	unsigned __stdcall ThreadCmdProcess(void* phProcess)
-	{
-		HANDLE hProcess = reinterpret_cast<HANDLE*>(phProcess);
-		WaitForSingleObject(hProcess, INFINITE);
-		CmdProcess::Get()->NotifyExitProcess();
-		return 0;
-	}
 }
 
 CmdProcess::CmdProcess() :
@@ -72,7 +194,9 @@ CmdProcess::CmdProcess() :
 	writePipeStdIn_{ NULL },
 	readPipeStdOut_{ NULL },
 	writePipeStdOut_{ NULL },
-	threadProcess_{ NULL }
+	threadProcess_{ NULL },
+	threadReadStdOut_{ NULL },
+	eventExit_{ NULL }
 {
 }
 
@@ -95,31 +219,26 @@ BOOL CmdProcess::Create(HWND hwnd)
 		return FALSE;
 	}
 
-	HANDLE readPipeStdIn = NULL;
-	HANDLE writePipeStdIn = NULL;
-	HANDLE readPipeStdOut = NULL;
-	HANDLE writePipeStdOut = NULL;
+	hwnd_ = hwnd;
 
 	SECURITY_ATTRIBUTES sa = { 0 };
 	sa.nLength = sizeof(sa);
 	sa.bInheritHandle = TRUE;
 
-	if (CreatePipe(&readPipeStdIn, &writePipeStdIn, &sa, 0) == FALSE) {
+	if (CreatePipeEx(&readPipeStdIn_, &writePipeStdIn_, &sa, 0, 0, 0) == FALSE) {
 		return FALSE;
 	}
 
-	if (CreatePipe(&readPipeStdOut, &writePipeStdOut, &sa, 0) == FALSE) {
-		CloseHandle(readPipeStdIn);
-		CloseHandle(writePipeStdIn);
+	if (CreatePipeEx(&readPipeStdOut_, &writePipeStdOut_, &sa, 0, FILE_FLAG_OVERLAPPED, 0) == FALSE) {
 		return FALSE;
 	}
 
 	STARTUPINFOW si = { 0 };
 	si.cb = sizeof(si);
 	si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
-	si.hStdOutput = writePipeStdOut;
-	si.hStdInput = readPipeStdIn;
-	si.hStdError = writePipeStdOut;
+	si.hStdOutput = writePipeStdOut_;
+	si.hStdInput = readPipeStdIn_;
+	si.hStdError = writePipeStdOut_;
 	si.wShowWindow = SW_HIDE;
 
 	std::wstring commandLine = szCmdExePath;
@@ -128,10 +247,6 @@ BOOL CmdProcess::Create(HWND hwnd)
 
 	PROCESS_INFORMATION pi = { 0 };
 	if (CreateProcessW(NULL, &commandLineBuffer.front(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi) == FALSE) {
-		CloseHandle(readPipeStdIn);
-		CloseHandle(writePipeStdIn);
-		CloseHandle(readPipeStdOut);
-		CloseHandle(writePipeStdOut);
 		return FALSE;
 	}
 
@@ -139,28 +254,38 @@ BOOL CmdProcess::Create(HWND hwnd)
 
 	CloseHandle(pi.hThread);
 
-	HANDLE threadProcess = StartThread(&ThreadCmdProcess, pi.hProcess);
-	if (threadProcess == NULL) {
-		CloseHandle(readPipeStdIn);
-		CloseHandle(writePipeStdIn);
-		CloseHandle(readPipeStdOut);
-		CloseHandle(writePipeStdOut);
+	hProcess_ = pi.hProcess;
+
+	eventExit_ = CreateEventW(NULL, FALSE, FALSE, NULL);
+	if (eventExit_ == NULL) {
 		return FALSE;
 	}
 
-	hwnd_ = hwnd;
-	hProcess_ = pi.hProcess;
-	readPipeStdIn_ = readPipeStdIn;
-	writePipeStdIn_ = writePipeStdIn;
-	readPipeStdOut_ = readPipeStdOut;
-	writePipeStdOut_ = writePipeStdOut;
-	threadProcess_ = threadProcess;
+	threadProcess_ = StartThread(&CmdProcess::ThreadCmdProcess, &hProcess_);
+	if (threadProcess_ == NULL) {
+		return FALSE;
+	}
+
+	threadReadStdOut_ = StartThread(&CmdProcess::ThreadReadStdOut, nullptr);
+	if (threadReadStdOut_ == NULL) {
+		return FALSE;
+	}
 
 	return TRUE;
 }
 
 BOOL CmdProcess::Exit()
 {
+	if (eventExit_) {
+		if (threadReadStdOut_) {
+			SetEvent(eventExit_);
+			WaitForSingleObject(threadReadStdOut_, 30 * 1000);
+			threadReadStdOut_ = NULL;
+		}
+		CloseHandle(eventExit_);
+		eventExit_ = NULL;
+	}
+
 	if (hwnd_) {
 		hwnd_ = NULL;
 	}
@@ -195,30 +320,18 @@ BOOL CmdProcess::Exit()
 	return TRUE;
 }
 
-LPWSTR CmdProcess::RunCommand(LPCWSTR lpszCommand)
+BOOL CmdProcess::RunCommand(LPCWSTR lpszCommand)
 {
 	if (hProcess_ == NULL) {
-		return nullptr;
-	}
-
-	if (readPipeStdIn_ == NULL) {
-		return nullptr;
+		return FALSE;
 	}
 
 	if (writePipeStdIn_ == NULL) {
-		return nullptr;
-	}
-
-	if (readPipeStdOut_ == NULL) {
-		return nullptr;
-	}
-
-	if (writePipeStdOut_ == NULL) {
-		return nullptr;
+		return FALSE;
 	}
 
 	if (!lpszCommand) {
-		return nullptr;
+		return FALSE;
 	}
 
 	WaitForSingleObject(hProcess_, 1000);
@@ -228,38 +341,10 @@ LPWSTR CmdProcess::RunCommand(LPCWSTR lpszCommand)
 
 	std::string writeBuf = ToString(command);
 	if (WriteFile(writePipeStdIn_, &writeBuf.front(), static_cast<DWORD>(writeBuf.length()), NULL, NULL) == FALSE) {
-		return nullptr;
+		return FALSE;
 	}
 
-	LPWSTR lpszReturn = L"";
-
-	CHAR readBuf[1025];
-	std::string str;
-	BOOL end = FALSE;
-	do {
-		WaitForSingleObject(hProcess_, 1000);
-		DWORD totalLen, len;
-		if (PeekNamedPipe(readPipeStdOut_, NULL, 0, NULL, &totalLen, NULL) && totalLen > 0) {
-			if (ReadFile(readPipeStdOut_, readBuf, sizeof(readBuf) - 1, &len, NULL) && len > 0) {
-				readBuf[len] = '\0';
-				str += readBuf;
-			}
-		}
-		else
-		{
-			end = TRUE;
-		}
-	} while (!end);
-	if (str.empty() == false) {
-		std::wstring wstr = ToWString(str);
-		TrimStringLine(&wstr);
-		lpszReturn = static_cast<LPWSTR>(GlobalAlloc(0, (wstr.length() + 1) * sizeof(WCHAR)));
-		if (lpszReturn) {
-			wcsncpy_s(lpszReturn, wstr.length() + 1, wstr.c_str(), wstr.length() + 1);
-		}
-	}
-
-	return lpszReturn;
+	return TRUE;
 }
 
 void CmdProcess::NotifyExitProcess()
@@ -267,4 +352,102 @@ void CmdProcess::NotifyExitProcess()
 	if (hwnd_) {
 		PostMessage(hwnd_, WM_CLOSE, 0, 0);
 	}
+}
+
+void CmdProcess::ReadStdOut()
+{
+	HANDLE eventRead = CreateEvent(NULL, FALSE, FALSE, NULL);
+	if (eventRead == NULL) {
+		return;
+	}
+
+	enum
+	{
+		EVENT_READ,
+		EVENT_EXIT,
+		EVENT_COUNT
+	};
+
+	HANDLE handles[EVENT_COUNT] =
+	{
+		eventRead,
+		eventExit_,
+	};
+
+	OVERLAPPED overlapped = { 0 };
+	overlapped.hEvent = eventRead;
+
+	WaitForSingleObject(hProcess_, 1000);
+
+	BOOL exit = FALSE;
+	BOOL reading = FALSE;
+
+	std::vector<char> buffers;
+	while (exit == FALSE) {
+		if (ReadFile(readPipeStdOut_, NULL, 0, NULL, &overlapped) == FALSE) {
+			if (GetLastError() != ERROR_IO_PENDING) {
+				continue;
+			}
+		}
+
+		const DWORD timeout = reading ? 500 : INFINITE;
+
+		const DWORD dwWaitResult = WaitForMultipleObjects(EVENT_COUNT, handles, FALSE, timeout);
+		switch (dwWaitResult) {
+		case WAIT_OBJECT_0 + EVENT_READ:
+			{
+				reading = TRUE;
+
+				DWORD totalBytesAvail = 0;
+				if (PeekNamedPipe(readPipeStdOut_, NULL, 0, NULL, &totalBytesAvail, NULL)) {
+					if (totalBytesAvail > 0) {
+						const size_t size = buffers.size();
+						buffers.resize(size + totalBytesAvail);
+
+						DWORD numberOfBytesRead = 0;
+						if (ReadFile(readPipeStdOut_, &buffers[size], totalBytesAvail, &numberOfBytesRead, NULL)) {
+							buffers.resize(size + numberOfBytesRead);
+						}
+					}
+				}
+			}
+			break;
+
+		case WAIT_OBJECT_0 + EVENT_EXIT:
+			exit = TRUE;
+			break;
+
+		case WAIT_TIMEOUT:
+			if (reading) {
+				reading = FALSE;
+
+				if (buffers.empty() == false) {
+					std::string str(buffers.cbegin(), buffers.cend());
+					buffers.clear();
+					std::wstring wstr = ToWString(str);
+					TrimStringLine(&wstr);
+					ChatData::Get()->PushBackOutput(wstr);
+					PostMessageW(hwnd_, WM_APP, 0, 0);
+				}
+			}
+			break;
+
+		default:
+			break;
+		}
+	}
+}
+
+unsigned int __stdcall CmdProcess::ThreadCmdProcess(void* phProcess)
+{
+	HANDLE hProcess = *static_cast<HANDLE*>(phProcess);
+	WaitForSingleObject(hProcess, INFINITE);
+	CmdProcess::Get()->NotifyExitProcess();
+	return 0;
+}
+
+unsigned int __stdcall CmdProcess::ThreadReadStdOut(void*)
+{
+	CmdProcess::Get()->ReadStdOut();
+	return 0;
 }

--- a/CmdProcess.h
+++ b/CmdProcess.h
@@ -31,4 +31,6 @@ private:
 	HANDLE threadProcess_;
 	HANDLE threadReadStdOut_;
 	HANDLE eventExit_;
+
+	BOOL commandLineErase_;
 };

--- a/CmdProcess.h
+++ b/CmdProcess.h
@@ -12,8 +12,13 @@ public:
 	static CmdProcess* Get();
 	BOOL Create(HWND hwnd);
 	BOOL Exit();
-	LPWSTR RunCommand(LPCWSTR lpszCommand);
+	BOOL RunCommand(LPCWSTR lpszCommand);
+
+private:
 	void NotifyExitProcess();
+	void ReadStdOut();
+	static unsigned int __stdcall ThreadCmdProcess(void* phProcess);
+	static unsigned int __stdcall ThreadReadStdOut(void*);
 
 private:
 	HWND hwnd_;
@@ -24,4 +29,6 @@ private:
 	HANDLE writePipeStdOut_;
 
 	HANDLE threadProcess_;
+	HANDLE threadReadStdOut_;
+	HANDLE eventExit_;
 };

--- a/CmdProcess.h
+++ b/CmdProcess.h
@@ -10,14 +10,18 @@ private:
 
 public:
 	static CmdProcess* Get();
-	BOOL Create();
+	BOOL Create(HWND hwnd);
 	BOOL Exit();
 	LPWSTR RunCommand(LPCWSTR lpszCommand);
+	void NotifyExitProcess();
 
 private:
+	HWND hwnd_;
 	HANDLE hProcess_;
 	HANDLE readPipeStdIn_;
 	HANDLE writePipeStdIn_;
 	HANDLE readPipeStdOut_;
 	HANDLE writePipeStdOut_;
+
+	HANDLE threadProcess_;
 };

--- a/CmdProcess.h
+++ b/CmdProcess.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <windows.h>
+
+class CmdProcess
+{
+private:
+	CmdProcess();
+	~CmdProcess();
+
+public:
+	static CmdProcess* Get();
+	BOOL Create();
+	BOOL Exit();
+	LPWSTR RunCommand(LPCWSTR lpszCommand);
+
+private:
+	HANDLE hProcess_;
+	HANDLE readPipeStdIn_;
+	HANDLE writePipeStdIn_;
+	HANDLE readPipeStdOut_;
+	HANDLE writePipeStdOut_;
+};

--- a/CriticalSection.cpp
+++ b/CriticalSection.cpp
@@ -1,0 +1,21 @@
+#include "CriticalSection.h"
+
+CriticalSection::CriticalSection() :
+	criticalSection_{}
+{
+	InitializeCriticalSection(&criticalSection_);
+}
+
+CriticalSection::~CriticalSection()
+{
+}
+
+void CriticalSection::Lock()
+{
+	EnterCriticalSection(&criticalSection_);
+}
+
+void CriticalSection::Unlock()
+{
+	LeaveCriticalSection(&criticalSection_);
+}

--- a/CriticalSection.h
+++ b/CriticalSection.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Windows.h>
+#include "SyncObject.h"
+
+class CriticalSection : public SyncObject
+{
+public:
+	CriticalSection();
+	virtual ~CriticalSection() override;
+
+	virtual void Lock() override;
+	virtual void Unlock() override;
+
+private:
+	CRITICAL_SECTION criticalSection_;
+};

--- a/ISyncObject.cpp
+++ b/ISyncObject.cpp
@@ -1,0 +1,1 @@
+#include "ISyncObject.h"

--- a/ISyncObject.h
+++ b/ISyncObject.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class ISyncObject
+{
+public:
+	virtual void Lock() = 0;
+	virtual void Unlock() = 0;
+};

--- a/SingleLock.cpp
+++ b/SingleLock.cpp
@@ -1,0 +1,25 @@
+#include "ISyncObject.h"
+#include "SingleLock.h"
+
+SingleLock::SingleLock(ISyncObject* syncObject, BOOL lock):
+	syncObject_{ syncObject }
+{
+	if (lock) {
+		syncObject_->Lock();
+	}
+}
+
+SingleLock::~SingleLock()
+{
+	syncObject_->Unlock();
+}
+
+void SingleLock::Lock()
+{
+	syncObject_->Lock();
+}
+
+void SingleLock::Unlock()
+{
+	syncObject_->Unlock();
+}

--- a/SingleLock.h
+++ b/SingleLock.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Windows.h>
+
+class ISyncObject;
+
+class SingleLock
+{
+public:
+	SingleLock() = delete;
+	SingleLock(const SingleLock&) = delete;
+	SingleLock(SingleLock&&) = delete;
+	SingleLock& operator =(const SingleLock&) = delete;
+	SingleLock& operator =(SingleLock&&) = delete;
+
+	explicit SingleLock(ISyncObject* syncObject, BOOL lock = TRUE);
+	~SingleLock();
+
+	void Lock();
+	void Unlock();
+
+private:
+	ISyncObject* syncObject_;
+};
+

--- a/Source.cpp
+++ b/Source.cpp
@@ -117,8 +117,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	static HBRUSH hBrush;
 	static HFONT hFont;
 	static UINT uDpiX = DEFAULT_DPI, uDpiY = DEFAULT_DPI;
-	static HANDLE hThread;
-	static LPWSTR lpszCommand;
 	switch (msg)
 	{
 	case WM_CREATE:
@@ -177,9 +175,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		SetFocus(hEdit);
 		break;
 	case WM_APP:
-		WaitForSingleObject(hThread, INFINITE);
-		CloseHandle(hThread);
-		hThread = 0;
 		{
 			std::wstring output;
 			while (ChatData::Get()->PopFrontOutput(&output)) {
@@ -281,7 +276,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		DestroyWindow(hWnd);
 		break;
 	case WM_DESTROY:
-		GlobalFree(lpszCommand);
 		pDocument.Release();
 		pWB2.Release();
 		DeleteObject(hBrush);
@@ -295,7 +289,12 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	return 0;
 }
 
-int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow)
+int WINAPI wWinMain(
+	_In_ HINSTANCE hInstance,
+	_In_opt_ HINSTANCE hPrevInstance,
+	_In_ LPWSTR lpCmdLine,
+	_In_ int nShowCmd
+)
 {
 	if (FAILED(CoInitialize(NULL)))
 	{

--- a/SyncObject.cpp
+++ b/SyncObject.cpp
@@ -1,0 +1,1 @@
+#include "SyncObject.h"

--- a/SyncObject.h
+++ b/SyncObject.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ISyncObject.h"
+
+class SyncObject : public ISyncObject
+{
+protected:
+	SyncObject() = default;
+
+public:
+	virtual ~SyncObject() = default;
+
+	SyncObject(const SyncObject&) = delete;
+	SyncObject(SyncObject&&) = delete;
+	SyncObject& operator =(const SyncObject&) = delete;
+	SyncObject& operator =(SyncObject&&) = delete;
+};

--- a/cmdchat.vcxproj
+++ b/cmdchat.vcxproj
@@ -162,15 +162,25 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="ChatData.cpp" />
     <ClCompile Include="CmdProcess.cpp" />
+    <ClCompile Include="CriticalSection.cpp" />
+    <ClCompile Include="SingleLock.cpp" />
     <ClCompile Include="Source.cpp" />
+    <ClCompile Include="ISyncObject.cpp" />
+    <ClCompile Include="SyncObject.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="resource\index.html" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ChatData.h" />
     <ClInclude Include="CmdProcess.h" />
+    <ClInclude Include="CriticalSection.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="SingleLock.h" />
+    <ClInclude Include="ISyncObject.h" />
+    <ClInclude Include="SyncObject.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="cmdchat.rc" />

--- a/cmdchat.vcxproj
+++ b/cmdchat.vcxproj
@@ -162,12 +162,14 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="CmdProcess.cpp" />
     <ClCompile Include="Source.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="resource\index.html" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CmdProcess.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
cmd.exeのプロセスを起動時に1回のみ生成する機能を実装しました。
以下の3つの機能を含んでいます。
- cmd.exeのプロセスを起動時に1回のみ生成する
- cmd.exeのプロセスを監視し、終了時にcmdchatも同期して終了する
- cmd.exeのstdoutを別スレッドで常に読み取り表示する

これにより、以下のIssueに対応できるのではないでしょうか？
#1 #15 #16  #17  #18  

※初めてのpull requestのため、不手際等ありましたら申し訳ございません。